### PR TITLE
Hash#to_params for easier CGI params building 

### DIFF
--- a/lib/core/facets/hash/to_params.rb
+++ b/lib/core/facets/hash/to_params.rb
@@ -1,0 +1,15 @@
+class Hash
+  # Allows for taking a hash and turning it into CGI params
+  # Since 1.8.x does not have ordered hashes the params might not
+  # be ordered.
+  
+  def to_params
+    map do |k,v|
+      if v.respond_to?(:join)
+        "#{k}=#{v.join(",")}"
+      else
+        "#{k}=#{v}"
+      end
+    end.join("&")
+  end
+end

--- a/test/core/hash/test_to_params.rb
+++ b/test/core/hash/test_to_params.rb
@@ -1,0 +1,13 @@
+covers 'facets/hash/to_params'
+
+testcase Hash do
+  unit :to_params do
+    hash1 = {:foo => "bar"}
+    hash2 = {"foo" => ["barf", "fab", 1]}
+    hash3 = {:foo => [:barf, :asdf,1], :fee => 1}
+    
+    hash1.to_params.assert == "foo=bar"
+    hash2.to_params.assert == "foo=barf,fab,1"
+    hash3.to_params.assert == "foo=barf,asdf,1&fee=1"
+  end
+end


### PR DESCRIPTION
I added the method Hash#to_params to make it easier to turn a hash into CGI params.

for instance

{:foo => "bar", :fi => "fo"}.to_params => "foo=bar&fi=fo"

I use this a ton and figure it's useful to be added to this library
