### PR TITLE
Fix for String.unindent()

### DIFF
--- a/lib/core/facets/string/indent.rb
+++ b/lib/core/facets/string/indent.rb
@@ -43,17 +43,29 @@ class String
     if size
       indent(-size)
     else
-      char = ' '
-      self.scan(/^[\ \t]*\S/) do |m|
-        if size.nil? || m.size < size
-          size = m.size
-          char = m[0...-1]
-        end
-      end
-      size -= 1
-      indent(-size, char)
+      ws = self.scan(/^([\ \t]*)\S/).flatten
+      prefix = common_prefix(*ws)
+      indent(-1, prefix)
     end
   end
+
+  def common_prefix(*strings)
+    return nil if strings.empty?
+    first = strings.shift
+    return first if strings.empty?
+
+    index = 0
+    while index < first.size
+      char = first[index...index+1]
+      strings.each do |str|
+        sub = str[index...index+1]
+        return str[0...index] unless sub == char
+      end
+      index += 1
+    end
+    first
+  end
+  private :common_prefix
 
   # Equivalent to String#unindent, but modifies the receiver in place.
   #

--- a/test/core/string/test_indent.rb
+++ b/test/core/string/test_indent.rb
@@ -81,10 +81,4 @@ test_case String do
 
   end
 
-  #method :unindent do
-  #  test "is an alias for negative indent" do
-  #    '  xyz'.unindent(2).assert == 'xyz'
-  #  end
-  #end
-
 end

--- a/test/core/string/test_unindent.rb
+++ b/test/core/string/test_unindent.rb
@@ -57,6 +57,46 @@ by.
       "   xyz".unindent(4).assert  == "xyz"
     end
 
+    test "unindents by the amount of the largest indent" do
+      expected = <<-EOF
+I must go down to the seas again
+  The lonely sea and the sky
+And all I want is a tall ship
+  And a star to steer her by
+      EOF
+      actual = ex1.unindent
+      actual.assert == expected
+    end
+
+    test "unindents by the amount of the largest indent - tabs and spaces" do
+      ex = "\t\t  I must go down to the seas again\n" +
+           "\t\t    The lonely sea and the sky\n" +
+           "\t\t  And all I want is a tall ship\n" +
+           "\t\t    And a star to steer her by\n"
+      expected = "I must go down to the seas again\n" +
+                 "  The lonely sea and the sky\n" +
+                 "And all I want is a tall ship\n" +
+                 "  And a star to steer her by\n"
+      actual = ex.unindent
+      actual.assert == expected
+    end
+
+    # There is arguably no right answer here, because there's no way to tell
+    # what a tab character means.  This behavior is arbitrary, but at least it
+    # is predictable.
+    test "unindents given inconsistent tab usage" do
+      ex = "\t  I must go down to the seas again\n" +
+           "\t\tThe lonely sea and the sky\n" +
+           "\t\t  And all I want is a tall ship\n" +
+           "\t    And a star to steer her by\n"
+      expected = "  I must go down to the seas again\n" +
+                 "\tThe lonely sea and the sky\n" +
+                 "\t  And all I want is a tall ship\n" +
+                 "    And a star to steer her by\n"
+      actual = ex.unindent
+      actual.assert == expected
+    end
+
     test "large example unindented one space" do
       expected = <<-EOF
    I must go down to the seas again


### PR DESCRIPTION
I noticed that calling unindent() doesn't do the right thing:

irb(main):001:0> require 'facets/string/unindent'
=> true
irb(main):002:0> "  two\n    four\n".unindent
=> "two\n four\n"

Note that there is only one space before 'four'; there should be two.  With this change, I get the correct output.

I ran the whole test suite and got no failures.

Incidentally, figuring out how to run the tests took a while.  It would be nice if Facets include a README-testing.txt file explaining that the tests use a framework called 'Lemon', and where to find it.  Google helped me figure that out.  The documentation on how to run Lemon tests was also out of date - this page:

https://github.com/rubyworks/lemon/wiki/Running-Tests

...advises running the 'lemon' command, when the real command appears to be called 'lemonade'.  And 'lemonade' didn't work for me anyway, producing a LoadError: "no such file to load -- test/cli".  I had to run "rubytest -r lemon test" (the docs say "ruby-test" but that was also incorrect).  I installed using 'sudo gem install lemon' and got lemon 0.9.0 and rubytest 0.3.1.  Let me know if something's wrong with my setup.
