### PR TITLE
update Hash#slice to behave more like the one in ActiveSupport

### DIFF
--- a/lib/core/facets/hash/slice.rb
+++ b/lib/core/facets/hash/slice.rb
@@ -2,13 +2,14 @@ class Hash
 
   # Returns a new hash with only the given keys.
   #
-  #   h = {:a=>1, :b=>2}
-  #   h.slice(:a)  #=> {:a=>1}
+  #   h = {:a=>1, :b=>2, :c=>3}
+  #   h.slice(:a, :c)  #=> {:a=>1, :c=>3}
+  #   h.slice(:a, :d)  #=> {:a=>1}
   #
   def slice(*keep_keys)
     hash = {}
     keep_keys.each do |key|
-      hash[key] = fetch(key)
+      hash[key] = self[key] if has_key?(key)
     end
     hash
   end

--- a/test/core/hash/test_slice.rb
+++ b/test/core/hash/test_slice.rb
@@ -4,9 +4,14 @@ test_case Hash do
 
   method :slice do
 
-    test do
+    test 'only existing keys' do
       h = {:a=>1,:b=>2,:c=>3}
       h.slice(:a, :b).assert == {:b=>2, :a=>1}
+    end
+
+    test 'with non-existent keys' do
+      h = {:a=>1,:b=>2,:c=>3}
+      h.slice(:a, :d).assert == {:a=>1}
     end
 
   end
@@ -17,6 +22,12 @@ test_case Hash do
       h = {:a=>1,:b=>2,:c=>3}
       h.slice!(:a, :b).assert == {:c=>3}
       h.assert == {:a=>1,:b=>2}
+    end
+
+    test do
+      h = {:a=>1,:b=>2,:c=>3}
+      h.slice!(:a, :d).assert == {:c=>3, :b=>2}
+      h.assert == {:a=>1}
     end
 
   end


### PR DESCRIPTION
I was trying to use facests with some code written originally for ActiveSupport Hash#slice and ran into trouble because it assumed that it was OK to supply keys as arguments to #slice that weren't necessarily in the hash.  I don't see any reason to be strict in this regard, so I've updated the implementation to follow the behavior.

I've updated the tests to verify this behavior as well.
