### PR TITLE
add to add rc gem to make tests run

### DIFF
--- a/.ruby
+++ b/.ruby
@@ -17,6 +17,10 @@ requirements:
   groups:
   - test
   development: true
+- name: rc
+  groups:
+  - test
+  development: true
 - name: detroit
   groups:
   - build


### PR DESCRIPTION
I got the following error when I tried to run the tests w/o adding rc:

16:11:19 ~/Projects/facets$ rubytest -r lemon
/Users/larry.baltz/.rvm/gems/ruby-1.9.3-p194/gems/rubytest-0.5.1/lib/rubytest/rc.rb:1:in `require': cannot load such file -- rc (LoadError)
    from /Users/larry.baltz/.rvm/gems/ruby-1.9.3-p194/gems/rubytest-0.5.1/lib/rubytest/rc.rb:1:in`<top (required)>'
    from /Users/larry.baltz/.rvm/gems/ruby-1.9.3-p194/gems/rubytest-0.5.1/lib/rubytest.rb:24:in `require_relative'
    from /Users/larry.baltz/.rvm/gems/ruby-1.9.3-p194/gems/rubytest-0.5.1/lib/rubytest.rb:24:in`<top (required)>'
    from /Users/larry.baltz/.rvm/gems/ruby-1.9.3-p194/gems/rubytest-0.5.1/bin/rubytest:2:in `require'
    from /Users/larry.baltz/.rvm/gems/ruby-1.9.3-p194/gems/rubytest-0.5.1/bin/rubytest:2:in`<top (required)>'
    from /Users/larry.baltz/.rvm/gems/ruby-1.9.3-p194/bin/rubytest:19:in `load'
    from /Users/larry.baltz/.rvm/gems/ruby-1.9.3-p194/bin/rubytest:19:in`<main>'
    from /Users/larry.baltz/.rvm/gems/ruby-1.9.3-p194/bin/ruby_noexec_wrapper:14:in `eval'
    from /Users/larry.baltz/.rvm/gems/ruby-1.9.3-p194/bin/ruby_noexec_wrapper:14:in`<main>'
