### PR TITLE
Fix for Enumerable#count

### DIFF
--- a/lib/core/facets/enumerable/count.rb
+++ b/lib/core/facets/enumerable/count.rb
@@ -38,7 +38,7 @@ module Enumerable
       r.size
     else
       begin
-				raise if size.nil?
+        raise if size.nil?
         size
       rescue
         i=0; each{ |e| i+=1 }; i


### PR DESCRIPTION
Previously returned nil when called on an Enumerator with no arguments.
