### PR TITLE
pull request to fix issue #99

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ web/
 work/sandbox
 work/trash
 Gemfile.lock
+.rvmrc
 *.gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
-source :rubygems
+source "https://rubygems.org"
 
 group :test do
   gem 'lemon'
   gem 'qed'
   gem 'rubytest-cli'
+  gem 'rake'
+  gem 'simplecov'
 end
 
 #group :build do


### PR DESCRIPTION
`rake` and `simplecov` are missing in the test group

furthermore it seems that `source :rubygems` is deprecated

fixing this allowed me to launch rake via `bundle exec`
