### PR TITLE
Added Range#nudge

### DIFF
--- a/lib/core/facets/range/nudge.rb
+++ b/lib/core/facets/range/nudge.rb
@@ -1,0 +1,29 @@
+class Range
+
+  # Nudge range values
+  #
+  #   (1..5).nudge           #=> 2..6
+  #   (1..5).nudge(2)        #=> 3..7
+  #   (1..5).nudge(-2)       #=> -1..3
+  #   (1..5).nudge(min: 1)   #=> 2..5
+  #   (1..5).nudge(max: 1)   #=> 1..6
+  #
+  # CREDIT: Codeindulgence
+
+  def nudge(options_or_number = 1)
+    if options_or_number.instance_of? Fixnum
+      {:min => options_or_number, :max => options_or_number}
+      min = options_or_number
+      max = options_or_number
+    else
+      min = options_or_number[:min].to_i
+      max = options_or_number[:max].to_i
+    end
+
+    if exclude_end?
+      (self.min + min)...((self.max + 1) + max)
+    else
+      (self.min + min)..(self.max + max)
+    end
+  end
+end

--- a/test/core/range/test_nudge.rb
+++ b/test/core/range/test_nudge.rb
@@ -1,0 +1,32 @@
+covers 'facets/range/nudge'
+
+test_case Range do
+  method :nudge do
+    test 'default nudge' do
+      (17..32).nudge.assert == (18..33)
+      (17..32).nudge.nudge.assert == (19..34)
+      (17...32).nudge.assert == (18...33)
+    end
+
+    test 'positive nudge' do
+      (1..9).nudge(2).assert == (3..11)
+      (1...9).nudge(2).assert == (3...11)
+    end
+
+    test 'negative nudge' do
+      (5..6).nudge(-2).assert == (3..4)
+      (5...6).nudge(-2).assert == (3...4)
+    end
+
+    test 'min nudge' do
+      (5..9).nudge(:min => 2).assert == (7..9)
+      (5...9).nudge(:min => 2).assert == (7...9)
+    end
+
+    test 'max nudge' do
+      (8..16).nudge(:max => 10).assert == (8..26)
+      (8...16).nudge(:max => 10).assert == (8...26)
+    end
+  end
+end
+


### PR DESCRIPTION
I had a need to alter the minimum value of a range, but couldn't find a method for it.
Range#nudge supports changing either the min, max or both values by "nudging" them by a given amount.