### PR TITLE
notation of broken tests Enumerable::Argumentable for discussion :test:

### DIFF
--- a/lib/standard/facets/enumargs.rb
+++ b/lib/standard/facets/enumargs.rb
@@ -51,6 +51,11 @@ module Enumerable
           end
         }
       else
+        # this branch is used when the method has a variable number of arguments
+        #   resulting in an arity of -1.  Right now this is bugged as it does
+        #   not pass the argument to the each, and always passes the argument
+        #   to the method.  This makes methods like .min amdn .max to act
+        #   in an unexpected manner.
         class_eval %{
           def #{m}( *args, &yld )
             enum_for(:each).#{m}( *args, &yld )

--- a/test/standard/test_enumargs.rb
+++ b/test/standard/test_enumargs.rb
@@ -52,11 +52,24 @@ test_case Enumerable::Arguments do
   method :min do
     test do
       t = @PlusArray.new([1,2,3])
-      t.min(4).assert = 5
+
+      # test is failing.  min has a variable number
+      #  of arguments which makes it .arity = -1.
+      #  given the way Argumentable works for arity -1
+      #  the method always passes the single argument to
+      #  the min method, and passes nothing to the each
+      #  resulting it taking the X smallest values of the
+      #  given and unchanged array
+      t.min(4).assert = 5 # returning [1,2,3]
     end
   end
 
   method :max do
+    # test is failing.  max has a variable number of arguments which makes it
+    #  .arity = -1.  given the way Argumentable works for arity -1 the method
+    #  always passes the single argument to the max method, and passes nothing
+    #  to the each resulting it taking the X largest values of the given and
+    #  unchanged array
     test do
       t = @PlusArray.new([1,2,3])
       t.max(4).assert == 7


### PR DESCRIPTION
The implementation of Enumerable::Argumentable is broken for methods with an .arity of -1 such as .min and .max.

I'm not sure what to do about it.