### PR TITLE
notation of broken tests NilClass::Ergo for discussion :test:

### DIFF
--- a/lib/core/facets/kernel/ergo.rb
+++ b/lib/core/facets/kernel/ergo.rb
@@ -35,7 +35,7 @@ class NilClass
   # CREDIT: Daniel DeLorme
 
   def ergo
-    @_ergo ||= Functor.new{ nil }
+    @_ergo ||= Functor.new{ nil } # raising "can't modify frozen NilClass"
     @_ergo unless block_given?
   end
 

--- a/lib/core/facets/kernel/ergo.rb
+++ b/lib/core/facets/kernel/ergo.rb
@@ -26,7 +26,7 @@ module Kernel
 end
 
 class NilClass
-
+  FUNCTOR = Functor.new{ nil }
   # Compliments Kernel#ergo.
   #
   #   "a".ergo{ |o| o.upcase } #=> "A"
@@ -35,8 +35,7 @@ class NilClass
   # CREDIT: Daniel DeLorme
 
   def ergo
-    @_ergo ||= Functor.new{ nil } # raising "can't modify frozen NilClass"
-    @_ergo unless block_given?
+    FUNCTOR unless block_given?
   end
 
 end

--- a/test/core/kernel/test_ergo.rb
+++ b/test/core/kernel/test_ergo.rb
@@ -6,12 +6,13 @@ test_case Kernel do
 
     test do
       "a".ergo.upcase.assert == "A"
-      nil.ergo.foobar.assert == nil
+      nil.ergo.foobar.assert == nil # test is raising "can't modify frozen NilClass"
+
     end
- 
+
     test do
       "a".ergo{ |o| o.upcase }.assert == "A"
-      nil.ergo{ |o| o.foobar }.assert == nil
+      nil.ergo{ |o| o.foobar }.assert == nil # test is raising "can't modify frozen NilClass"
     end
 
   end
@@ -24,7 +25,7 @@ test_case NilClass do
 
     test do
       "a".ergo{ |o| o.upcase }.assert == "A"
-      nil.ergo{ |o| o.bar }.assert == nil
+      nil.ergo{ |o| o.bar }.assert == nil # test is raising "can't modify frozen NilClass"
     end
 
   end

--- a/test/core/kernel/test_ergo.rb
+++ b/test/core/kernel/test_ergo.rb
@@ -6,13 +6,13 @@ test_case Kernel do
 
     test do
       "a".ergo.upcase.assert == "A"
-      nil.ergo.foobar.assert == nil # test is raising "can't modify frozen NilClass"
+      nil.ergo.foobar.assert == nil
 
     end
 
     test do
-      "a".ergo{ |o| o.upcase }.assert == "A"
-      nil.ergo{ |o| o.foobar }.assert == nil # test is raising "can't modify frozen NilClass"
+      "a".ergo { |o| o.upcase }.assert == "A"
+      nil.ergo { |o| o.foobar }.assert == nil
     end
 
   end
@@ -24,8 +24,9 @@ test_case NilClass do
   method :ergo do
 
     test do
-      "a".ergo{ |o| o.upcase }.assert == "A"
-      nil.ergo{ |o| o.bar }.assert == nil # test is raising "can't modify frozen NilClass"
+      "a".ergo { |o| o.upcase }.assert   == "A"
+      nil.ergo { |o| o.bar }.assert      == nil
+      nil.ergo.ergo { |o| o.bar }.assert == nil
     end
 
   end


### PR DESCRIPTION
Did they freeze NilClass, since this was written?  I can't find anything about it.  
Error message
```
    can't modify frozen NilClass
    lib/core/facets/kernel/ergo.rb:38
    36 
    37   def ergo
 => 38     @_ergo ||= Functor.new{ nil }
    39     @_ergo unless block_given?
    40   end
    lib/core/facets/kernel/ergo.rb:38
    test/core/kernel/test_ergo.rb:27
    /home/scottp/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubytest-cli-0.2.0/lib/rubytest-cli.rb:48
    /home/scottp/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubytest-cli-0.2.0/lib/rubytest-cli.rb:18
    /home/scottp/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubytest-cli-0.2.0/bin/ruby-test:4
    /home/scottp/.rbenv/versions/2.2.0/bin/ruby-test:23
```