### PR TITLE
add Guardfile :test:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :test do
   gem 'lemon'
   gem 'qed'
   gem 'rubytest-cli'
+  gem 'guard-shell'
   gem 'rake'
   gem 'simplecov'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ group :test do
   gem 'lemon'
   gem 'qed'
   gem 'rubytest-cli'
-  gem 'guard-shell'
+  gem 'guard'
   gem 'rake'
   gem 'simplecov'
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,56 @@
+# to run both groups
+# $ bundle exec guard
+
+# to run just qed demos
+# $ bundle exec guard -g qed
+
+# to run just tests
+# $ bundle exec guard -g test
+
+PATH = "lib/core:lib/standard"
+# the double-colons below are *required* for inline Guards!!!
+
+module ::Guard
+  class Qed < Plugin
+    def run_all
+      puts 'Running all demos'
+      puts `qed -I#{PATH} demo`
+    end
+
+    def run_on_modifications(paths)
+      puts "Running demo for #{paths}"
+      puts `qed -I#{PATH} #{paths.join(' ')}`
+    end
+  end
+end
+
+module ::Guard
+  class Rubytest < Plugin
+
+    def run_all
+      puts 'Running all tests'
+      puts `ruby-test test`
+    end
+
+    def run_on_modifications(paths)
+      puts "Running test for #{paths}"
+      puts `ruby-test #{paths}`
+    end
+  end
+end
+
+group :qed do
+  guard :qed do
+    watch('demo/applique/') { 'demo' }
+    watch(%r{^lib/(.+)/facets/(.+\.rdoc)$}) { |m| "demo/#{m[1]}/#{m[2]}" }
+    watch(%r{^demo/.+/.+\.rdoc$}) { |m| m[0] }
+  end
+end
+
+group :test do
+  guard :rubytest do
+    watch('etc/test.rb') { 'test' }
+    watch(%r{^lib/(.+)/facets/(.+\.rb)$}) { |m| "test/#{m[1]}/#{m[2]}" }
+    watch(%r{^test/.+/test_.+\.rb$}) { |m| "#{m[0]}" }
+  end
+end

--- a/Guardfile
+++ b/Guardfile
@@ -33,8 +33,8 @@ module ::Guard
     end
 
     def run_on_modifications(paths)
-      puts "Running test for #{paths}"
-      puts `ruby-test #{paths}`
+      puts "Running test for #{paths.join(' ')}"
+      puts `ruby-test #{paths.join(' ')}`
     end
   end
 end

--- a/etc/test.rb
+++ b/etc/test.rb
@@ -15,9 +15,9 @@ tmp = File.join(File.dirname(__FILE__), 'tmp')
 FileUtils.mkdir(tmp) unless File.directory?(tmp)
 
 # Default test run.
-Test.run do |r|
-  r.files << 'test'
-end
+# Test.run do |r|
+#   r.files << 'test'
+# end
 
 # Generate SimpleCov coverage report.
 Test.run :cov do |r|


### PR DESCRIPTION
This is a small set of changes to enable the guard file watcher to run dems and tests as those files change.  The change is almost as small as I could make them with the exception of changing the etc/test.rb It shouldn't affect any existing workflows unless they depend on that setting in the etc/test.rb file.

Even if you don't want it as a permanent change please accept my humble petiton to include it while I'm cleaning up tests and deome to save me the frustration of rebasing.  guard is really essential to the way I like to work.

pretty please? 