### PR TITLE
Add split_at method.

### DIFF
--- a/demo/core/array/split_at.md
+++ b/demo/core/array/split_at.md
@@ -1,0 +1,12 @@
+## Array#split_at
+
+    require 'facets/array/split_at'
+    
+Split on the first element that matches using Array#index.
+
+    ['a','b','c'].split_at('b').assert == [['a'],'b',['c']]
+    
+    a = ['a1','a2','b12','a3','b2','a4']
+    a.split_at{|e| e.size == 3}.assert == [['a1','a2'],'b12',['a3','b2','a4']]
+    
+    

--- a/lib/core/facets/array/split_at.rb
+++ b/lib/core/facets/array/split_at.rb
@@ -1,0 +1,25 @@
+class Array
+
+  # Split on matching pattern. Breaks the array into [before, middle, after]
+  # segments. Uses Array#index to find the middle element.
+  #
+  # Examples
+  #
+  #   ['a1','a2','b1','a3','b2','a4'].split('b1')
+  #   #=> [['a1','a2'],b1,['a3','b2','a4']]
+  #
+  #   ['a1','a2','b1','a3','b2','a4'].split('foo')
+  #   #=> [[],nil,[]]
+  #
+  # Returns list of split-up arrays. [Tuple<Array,Object,Array>]
+
+  def split_at(*args, &block)
+    if middle = index(*args, &block)
+      [self[0...middle], self[middle], self[middle+1..-1]]
+    else
+      [[], nil, []]
+    end
+  end
+
+end
+

--- a/test/core/array/test_split_at.rb
+++ b/test/core/array/test_split_at.rb
@@ -1,0 +1,26 @@
+covers 'facets/array/split_at'
+
+test_case Array do
+
+  method :split_at do
+
+    test do
+      ['a','b','c'].split_at('b').assert == [['a'], 'b', ['c']]
+    end
+
+    test "empty" do
+      [].split_at('a').assert == [[], nil, []]
+    end
+
+    test "same" do
+      ['a'].split_at('a').assert == [[], 'a', []]
+    end
+
+    test "block" do
+      ['a','b','c'].split_at{|e| e == 'b'}.assert == [['a'], 'b', ['c']]
+    end
+
+  end
+
+end
+


### PR DESCRIPTION
This method is more useful for complex objects, e.g. splitting a list of User objects to find users before and after a given user. In this case you'd normally provide a block.

This is building fine but there is something wrong with 1.9.3 on travis. Perhaps it should be deprecated? e.g. build 2.x only?

Note: I closed the other PR because it was from the master branch and I couldn't change it.