### PR TITLE
Modernize Hash#slice

### DIFF
--- a/lib/core/facets/hash/slice.rb
+++ b/lib/core/facets/hash/slice.rb
@@ -13,11 +13,9 @@ class Hash
       end
     end
 
-    hash = {}
-    keep_keys.each do |key|
+    keep_keys.each_with_object({}) do |key, hash|
       hash[key] = fetch(key) if key?(key)
     end
-    hash
   end
 
   # Replaces hash with a new hash having only the given keys.


### PR DESCRIPTION
Since facets supports MRI > 2.0 and rbx and jruby both have each_with_object
looks like it is safe to modernize this Hash#slice to take advantage of
the feature added on MRI 1.9