### PR TITLE
Fix rubytest not running on CI :test:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: ruby
-script: "bundle exec rubytest -v -Ilib test/"
+script: "bundle exec rubytest -Ilib test/ --verbose"
 bundler_args: --without guard
 rvm:
   - 2.3.0


### PR DESCRIPTION
on my last PR I checked the test locally and the unit test related to my change were green, but when I checked on Travis they look green but also extremely fast (0.30 seconds for the whole test suite):

![rubytest_no_verbose](https://cloud.githubusercontent.com/assets/1037088/20475933/2d5d9f42-af83-11e6-8d2e-51ccc3500db6.png)

Having a more close look, you can see the problem (line 199): `ambiguous option: -v` which happens to return a 'valid' return value that Travis interpret as OK.

With this change (if accepted) there will be at the moment 10 test broken that will need to be fixed. 

