### PR TITLE
Alias `characters` to the `each_char` method

### DIFF
--- a/lib/core/facets/string/characters.rb
+++ b/lib/core/facets/string/characters.rb
@@ -4,10 +4,7 @@ class String
   #
   #   "abc".characters.to_a  #=> ["a","b","c"]
   #
-  # TODO: Probably should make this an enumerator. With #scan?
-  def characters
-    split(//)
-  end
+  alias :characters, :each_char
 
 end
 


### PR DESCRIPTION
In my opinion this method is no longer needed (`String#chars` and `String#each_char` have been implemented since at least 2.0) but it can be kept for backwards compatibility.