### PR TITLE
Add Exception#add_context, reraise_with_context

### DIFF
--- a/lib/core/facets/enumerable/reraise_with_context.rb
+++ b/lib/core/facets/enumerable/reraise_with_context.rb
@@ -1,0 +1,40 @@
+require 'facets/kernel/reraise_with_context'
+
+module Enumerable
+
+  # Returns an Enumerator that adds an exception handler that adds the value of each block argument
+  # as context to any exceptions that are raised by that iteration.
+  #
+  # Example:
+  #   User.find_each.reraise_with_context do |user|
+  #     send_reminder_email(user)
+  #   end
+  #
+  # See also: Kernel#reraise_with_context
+  #
+  def reraise_with_context
+    return enum_for(__callee__) unless block_given?
+
+    each do |*args|
+      Kernel.reraise_with_context(args: args) do
+        yield *args
+      end
+    end
+  end
+end
+
+class Enumerator::Lazy
+  # Lazy version of Enumerable#reraise_with_context
+  #
+  def reraise_with_context
+    unless block_given?
+      raise ArgumentError, "tried to call lazy #{__callee__} without a block"
+    end
+
+    lazy.map do |*args|
+      Kernel.reraise_with_context(args: args) do
+        yield *args
+      end
+    end
+  end
+end

--- a/lib/core/facets/exception/add_context.rb
+++ b/lib/core/facets/exception/add_context.rb
@@ -1,0 +1,9 @@
+class Exception
+  attr_reader :context
+
+  def add_context(context)
+    @context ||= {}
+    context.is_a?(Hash) or raise "expected context to be a Hash but was: #{context.inspect}"
+    @context.merge!(context)
+  end
+end

--- a/lib/core/facets/exception/reraise_with_context.rb
+++ b/lib/core/facets/exception/reraise_with_context.rb
@@ -1,0 +1,18 @@
+require 'facets/exception/add_context'
+
+class Exception
+  # Rescues the given exception (self), adds the given context, and re-raises
+  #
+  # See also: Kernel#reraise_with_context
+  #
+  def self.reraise_with_context(context)
+    context.is_a?(Hash) or raise "expected context to be a Hash but was: #{context.inspect}"
+    begin
+      yield
+    rescue self
+      $!.add_context(context)
+      raise
+    end
+  end
+end
+

--- a/lib/core/facets/kernel/reraise_with_context.rb
+++ b/lib/core/facets/kernel/reraise_with_context.rb
@@ -1,0 +1,43 @@
+# Moved to lib/core/facets/exception/reraise_with_context.rb
+require 'facets/exception/add_context'
+
+module Kernel
+  # Rescues the given class of exceptions (defaults to Exception), adds the given context, and
+  # re-raises with this additional context.
+  #
+  # This is especially useful inside a loop, allowing you to provide details about the specific
+  # iteration where the error was encountered, so that your general-purpose error handler (possibly
+  # at a much higher level in the app) can report to you
+  #
+  #   begin
+  #     …
+  #     users.each.with_index do |user, i|
+  #       reraise_with_context(user: user, i: i) do
+  #         send_reminder_email(user)
+  #       end
+  #     end
+  #
+  #     User.find_each do |user|
+  #       reraise_with_context(args: [user]) do
+  #         send_reminder_email(user)
+  #       end
+  #     end
+  #     …
+  #   rescue
+  #     # $!.context[:user], etc. is available here
+  #     report_error $!, $!.context
+  #   end
+  #
+  # See also: Enumerable#reraise_with_context, Exception.reraise_with_context
+  #
+  def reraise_with_context(exception_to_rescue = Exception, context)
+    exception_to_rescue <= Exception or raise "expected exception_to_rescue to be an Exception class but was: #{exception_to_rescue.inspect}"
+    context.is_a?(Hash) or raise "expected context to be a Hash but was: #{context.inspect}"
+    begin
+      yield
+    rescue exception_to_rescue
+      $!.add_context(context)
+      raise
+    end
+  end
+end

--- a/test/core/exception/test_add_context.rb
+++ b/test/core/exception/test_add_context.rb
@@ -1,0 +1,27 @@
+covers 'facets/exception/add_context'
+
+test_case Exception do
+
+  method :add_context do
+    def exception
+      0/0 rescue $!
+    end
+
+    test 'errors if non-hash' do
+      exc = exception()
+      RuntimeError.assert.raised? {
+        exc.add_context("here's some context")
+      }
+    end
+
+    test 'merges hashes' do
+      exc = exception()
+      exc.add_context(file: __FILE__)
+      exc.add_context(test_name: 'merges hashes')
+      exc.context.assert == {
+        file: __FILE__,
+        test_name: 'merges hashes',
+      }
+    end
+  end
+end

--- a/test/core/exception/test_reraise_with_context.rb
+++ b/test/core/exception/test_reraise_with_context.rb
@@ -1,0 +1,115 @@
+covers 'facets/kernel/reraise_with_context'
+covers 'facets/exception/reraise_with_context'
+covers 'facets/enumerable/reraise_with_context'
+
+test_case Kernel do
+  method :reraise_with_context do
+    test 'simple' do
+      reraise_with_context(some: 'context') do
+        0.supercalafragalistic
+      end rescue (exc = $!)
+      exc.assert.is_a? NoMethodError
+      exc.context.assert == {some: 'context'}
+    end
+
+    test 'simple' do
+      reraise_with_context(NameError, some: 'context') do
+        0.supercalafragalistic
+      end rescue (exc = $!)
+      exc.assert.is_a? NoMethodError
+      exc.context.assert == {some: 'context'}
+    end
+
+    test 'non-matching exception class' do
+      reraise_with_context(RuntimeError, some: 'context') do
+        0.supercalafragalistic
+      end rescue (exc = $!)
+      exc.assert.is_a? NoMethodError
+      exc.context.assert == nil
+    end
+
+    test 'adding context from a loop' do
+      [2, 1, 0].each do |n|
+        reraise_with_context(n: n) do
+          10 / n
+        end
+      end rescue (exc = $!)
+      exc.assert.is_a? ZeroDivisionError
+      exc.context.assert == {n: 0}
+    end
+  end
+end
+
+test_case Exception do
+  class_method :reraise_with_context do
+    test 'simple' do
+      NameError.reraise_with_context(some: 'context') do
+        0.supercalafragalistic
+      end rescue (exc = $!)
+      exc.assert.is_a? NoMethodError
+      exc.context.assert == {some: 'context'}
+    end
+
+    test 'non-matching exception class' do
+      RuntimeError.reraise_with_context(some: 'context') do
+        0.supercalafragalistic
+      end rescue (exc = $!)
+      exc.assert.is_a? NoMethodError
+      exc.context.assert == nil
+    end
+
+    test 'adding context from a loop' do
+      [3, 2, 1, 0].each do |n|
+        StandardError.reraise_with_context(n: n) do
+          10 / n
+        end
+      end rescue (exc = $!)
+      exc.context.assert == {n: 0}
+    end
+  end
+end
+
+test_case Enumerable do
+  method :reraise_with_context do
+    test 'reraise_with_context.each' do
+      [2, 1, 0].reraise_with_context.each do |n|
+        10 / n
+      end rescue (exc = $!)
+      exc.assert.is_a? ZeroDivisionError
+      exc.context.assert == {args: [0]}
+    end
+
+    test 'each.with_index.reraise_with_context' do
+      enum = [2, 1, 0].each.with_index.reraise_with_context
+      enum.each do |n, i|
+        10 / n
+      end rescue (exc = $!)
+      exc.assert.is_a? ZeroDivisionError
+      exc.context.assert == {args: [0, 2]}
+    end
+  end
+end
+
+test_case Enumerator::Lazy do
+  method :reraise_with_context do
+    test 'lazy.reraise_with_context' do
+      enum = (-1..Float::INFINITY).lazy.reraise_with_context do |n|
+        10 / n
+      end
+      enum.assert.is_a? Enumerator::Lazy
+      enum.first(3) rescue (exc = $!)
+      exc.assert.is_a? ZeroDivisionError
+      exc.context.assert == {args: [0]}
+    end
+
+    test 'lazy.with_index.reraise_with_context' do
+      enum = (-2..Float::INFINITY).lazy.with_index.reraise_with_context do |n, i|
+        10 / n
+      end
+      enum.assert.is_a? Enumerator::Lazy
+      enum.first(3) rescue (exc = $!)
+      exc.assert.is_a? ZeroDivisionError
+      exc.context.assert == {args: [0, 2]}
+    end
+  end
+end


### PR DESCRIPTION
Adds `Exception#context`, which is kind of like [`Exception#cause`](https://ruby-doc.org/core-2.7.0/Exception.html#method-i-cause) except it gives additional details about the location/context where the error occurred — in case the `backtrace` is not enough context. 

The main use case for this is loops. There's nothing more annoying than getting an exception notification about an error in a loop that just iterated over 1000 objects, and having no idea _which_ iteration/object actually caused the exception.

An error like that may indicate a problem with your **data/object** (like an attribute that should never be able to be `nil` but was `nil`) as much as it does a problem with your **code** (you probably should have programmed more defensively). While the default exception details give you enough information to fix your **code** to not allow the error to happen again, it would be _nice_ if it also told you _which_ **data** was to blame for this particular error.

Since you didn't capture that detail the first time, your only recourse is to either make a guess as to what the fix would be to handle the unexpected data (without ever seeing what that data was) or add additional error handling logic to gather more details the next time, and then (since you don't know which iteration to start from, unless you have logging/saved the state as you go) re-run the entire loop again (assuming that the side-effects of running it again are not too problematic).

`reraise_with_context` aims to make it so easy to capture those details the first time that you just _always_ remember to add that  extra context within any loops.
