### PR TITLE
gemspec: Drop now-unused directive test_files

### DIFF
--- a/facets.gemspec
+++ b/facets.gemspec
@@ -249,8 +249,6 @@ module Indexer
         gemspec.default_executable = gemspec.executables.first
       end
 
-      gemspec.test_files = glob_files(patterns[:test])
-
       unless gemspec.files.include?('.document')
         gemspec.extra_rdoc_files = glob_files(patterns[:doc])
       end


### PR DESCRIPTION
RubyGems.org does nothing with this directive. Can be removed without a replacement.