### PR TITLE
Fix syntax typo for tuple

### DIFF
--- a/lib/standard/facets/tuple.rb
+++ b/lib/standard/facets/tuple.rb
@@ -42,7 +42,7 @@ class Tuple
     if block_given?
       values = []
       arg.times { |i| values << block[i] }
-    elseif Integer === arg
+    elsif Integer === arg
       values = [ default ] * arg
     else
       values = arg.to_ary
@@ -54,7 +54,7 @@ class Tuple
     if block_given?
       @values = []
       arg.times { |i| @values << blk[i] }
-    elseif Integer === arg
+    elsif Integer === arg
       @values = [ default ] * arg
     else
       @values = arg.to_ary


### PR DESCRIPTION
Hello!

Ruby does not have `elseif` operator. 

So in this case when `block_given?` is `true` this part is interpreted as method call like `elseif(Integer === arg)`.