### PR TITLE
Fix typo in String#to_b doc

### DIFF
--- a/lib/core/facets/boolean.rb
+++ b/lib/core/facets/boolean.rb
@@ -86,7 +86,7 @@ class String
   #
   # All other strings return false.
   #
-  # Here are some exmamples.
+  # Here are some examples.
   #
   #   "true".to_b   #=> true
   #   "yes".to_b    #=> true


### PR DESCRIPTION
Typo: `exmamples` => `examples`

![image](https://github.com/rubyworks/facets/assets/11419017/e4abb0f1-b95c-4fc2-b689-a5e72e67f225)
