### PR TITLE
Support block defaults for cattr and mattr

### DIFF
--- a/lib/core/facets/module/mattr.rb
+++ b/lib/core/facets/module/mattr.rb
@@ -19,13 +19,13 @@ class Module
   # @uncommon
   #   require 'facets/module/cattr'
   #
-  def cattr(*syms)
+  def cattr(*syms, &block)
     writers, readers = syms.flatten.partition{ |a| a.to_s =~ /=$/ }
     writers = writers.map{ |e| e.to_s.chomp('=').to_sym }
     ##readers.concat( writers ) # writers also get readers
 
-    cattr_reader(*readers)
-    cattr_writer(*writers)
+    cattr_reader(*readers, &block)
+    cattr_writer(*writers, &block)
 
     return readers + writers
   end
@@ -49,7 +49,7 @@ class Module
   # @uncommon
   #   require 'facets/module/cattr'
   #
-  def cattr_reader(*syms)
+  def cattr_reader(*syms, &block)
     syms.flatten.each do |sym|
       module_eval(<<-EOS, __FILE__, __LINE__)
         unless defined? @@#{sym}
@@ -64,6 +64,7 @@ class Module
           @@#{sym}
         end
       EOS
+      class_variable_set("@@#{sym}", block.call) if block
     end
     return syms
   end
@@ -91,7 +92,7 @@ class Module
   # @uncommon
   #   require 'facets/module/cattr'
   #
-  def cattr_writer(*syms)
+  def cattr_writer(*syms, &block)
     syms.flatten.each do |sym|
       module_eval(<<-EOS, __FILE__, __LINE__)
         unless defined? @@#{sym}
@@ -106,6 +107,7 @@ class Module
           @@#{sym}=(obj)
         end
       EOS
+      class_variable_set("@@#{sym}", block.call) if block
     end
     return syms
   end
@@ -130,8 +132,8 @@ class Module
   # @uncommon
   #   require 'facets/module/cattr'
   #
-  def cattr_accessor(*syms)
-    cattr_reader(*syms) + cattr_writer(*syms)
+  def cattr_accessor(*syms, &block)
+    cattr_reader(*syms, &block) + cattr_writer(*syms)
   end
 
   # Creates a class-variable attribute that can
@@ -159,13 +161,13 @@ class Module
   # @uncommon
   #   require 'facets/module/mattr'
   #
-  def mattr(*syms)
+  def mattr(*syms, &block)
     writers, readers = syms.flatten.partition{ |a| a.to_s =~ /=$/ }
     writers = writers.collect{ |e| e.to_s.chomp('=').to_sym }
     ##readers.concat( writers ) # writers also get readers
 
-    mattr_writer( *writers )
-    mattr_reader( *readers )
+    mattr_writer( *writers, &block )
+    mattr_reader( *readers, &block )
 
     return readers + writers
   end
@@ -189,7 +191,7 @@ class Module
   # @uncommon
   #   require 'facets/module/mattr'
   #
-  def mattr_reader( *syms )
+  def mattr_reader( *syms, &block )
     syms.flatten.each do |sym|
       module_eval(<<-EOS, __FILE__, __LINE__)
         unless defined? @@#{sym}
@@ -204,6 +206,7 @@ class Module
           @@#{sym}
         end
       EOS
+      class_variable_set("@@#{sym}", block.call) if block
     end
     return syms
   end
@@ -232,7 +235,7 @@ class Module
   # @uncommon
   #   require 'facets/module/mattr'
   #
-  def mattr_writer(*syms)
+  def mattr_writer(*syms, &block)
     syms.flatten.each do |sym|
       module_eval(<<-EOS, __FILE__, __LINE__)
         unless defined? @@#{sym}
@@ -247,6 +250,7 @@ class Module
           @@#{sym}=(obj)
         end
       EOS
+      class_variable_set("@@#{sym}", block.call) if block
     end
     return syms
   end
@@ -272,8 +276,8 @@ class Module
   # @uncommon
   #   require 'facets/module/mattr'
   #
-  def mattr_accessor(*syms)
-    mattr_reader(*syms) + mattr_writer(*syms)
+  def mattr_accessor(*syms, &block)
+    mattr_reader(*syms, &block) + mattr_writer(*syms)
   end
 
 end

--- a/test/core/module/test_mattr.rb
+++ b/test/core/module/test_mattr.rb
@@ -1,0 +1,59 @@
+covers 'facets/module/mattr'
+
+test_case Module do
+
+  method :cattr_reader do
+
+    test do
+      c = Class.new do
+        cattr_reader(:setting) { :default }
+      end
+
+      c.setting.assert == :default
+      c.new.setting.assert == :default
+    end
+
+  end
+
+  method :cattr_accessor do
+
+    test do
+      c = Class.new do
+        cattr_accessor(:setting) { :default }
+      end
+
+      c.setting.assert == :default
+      c.setting = :changed
+      c.new.setting.assert == :changed
+    end
+
+  end
+
+  method :mattr_reader do
+
+    test do
+      c = Class.new do
+        mattr_reader(:setting) { :default }
+      end
+
+      c.setting.assert == :default
+      c.new.setting.assert == :default
+    end
+
+  end
+
+  method :mattr_accessor do
+
+    test do
+      c = Class.new do
+        mattr_accessor(:setting) { :default }
+      end
+
+      c.setting.assert == :default
+      c.setting = :changed
+      c.new.setting.assert == :changed
+    end
+
+  end
+
+end


### PR DESCRIPTION
## Summary

- Adds block defaults to `cattr`/`cattr_reader`/`cattr_writer`/`cattr_accessor`
- Mirrors the same block-default behavior for `mattr` helpers
- Adds focused module tests for reader/accessor defaults and write-after-default behavior

IssueHunt bounty:
- https://github.com/rubyworks/facets/issues/258
- https://issuehunt.io/repos/341331/issues/258

## Testing

- `bundle install --path vendor/bundle --without guard`
- `bundle exec ruby-test -Ilib/core test/core/module/test_mattr.rb`
- `bundle exec ruby-test -Ilib/core test/core/module`
- `ruby -c lib/core/facets/module/mattr.rb`
- direct Ruby smoke for `cattr_accessor` and `mattr_accessor` block defaults
- `git diff --check`

Note: a plain `bundle install --path vendor/bundle` tries to install the optional `guard` group and fails on this machine because `ffi-1.17.4-x86_64-darwin` requires Ruby >= 3.0, while the system Ruby here is 2.6.10. Installing without the `guard` group was enough for the test suite commands above.
